### PR TITLE
Bug fixes and refactors in follow up to last big refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 SHELL := /bin/bash
 
-TOXENV = $(shell python3 -c "import sys; print(\"py{}{}\".format(sys.version_info.major, sys.version_info.minor))")
-
-.PHONY: all clean clean_all test
+.PHONY: all clean clean_all test example-project
 
 all: clean test
 
@@ -10,14 +8,14 @@ clean:
 	-rm -r example-project
 
 clean_all: clean
-	-rm -r .tox .virtualenv
+	-rm -r .virtualenv
 
 .virtualenv/bin/activate:
 	virtualenv -p python3 .virtualenv
-	.virtualenv/bin/pip3 install tox
+	.virtualenv/bin/pip3 install cookiecutter tox
 
 example-project: .virtualenv/bin/activate
-	.virtualenv/bin/tox
+	source .virtualenv/bin/activate && cookiecutter . --no-input
 
 test: example-project .virtualenv/bin/activate
 	source .virtualenv/bin/activate && cd ./example-project && make

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,0 @@
-[tox]
-envlist = py{35,36}
-skipsdist = true
-
-[testenv]
-whitelist_externals = bash
-deps = 
-    cookiecutter
-commands = cookiecutter . --no-input 

--- a/{{ cookiecutter.project_pkg_name }}/Makefile
+++ b/{{ cookiecutter.project_pkg_name }}/Makefile
@@ -3,7 +3,7 @@
 #
 
 SHELL := /bin/bash
-TOXENV = $(shell python3 -c "import sys; print(\"py{}{}\".format(sys.version_info.major, sys.version_info.minor))")
+export TOXENV = $(shell python3 -c "import sys; print(\"py{}{}\".format(sys.version_info.major, sys.version_info.minor))")
 
 ## setup default target
 all: clean lint test dist
@@ -39,7 +39,8 @@ clean_test:
 
 ## lint with pylint
 lint:
-	@echo "no op"
+	tox --notest
+	.tox/$(TOXENV)/bin/pylint --rcfile pylintrc {{ cookiecutter.project_module_name }}
 
 ## run tests
 test:

--- a/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
@@ -11,3 +11,5 @@ pytest-cov==2.4.0
 # Install dependencies
 -r requirements.txt
 
+# General dev dependencies
+pylint==1.7.1

--- a/{{ cookiecutter.project_pkg_name }}/pylintrc
+++ b/{{ cookiecutter.project_pkg_name }}/pylintrc
@@ -45,7 +45,7 @@ optimize-ast=no
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
 confidence=
 
-# Enable the message, ceport, category or checker with the given id(s). You can
+# Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time. See also the "--disable" option for examples.
 #enable=

--- a/{{ cookiecutter.project_pkg_name }}/pylintrc
+++ b/{{ cookiecutter.project_pkg_name }}/pylintrc
@@ -45,7 +45,7 @@ optimize-ast=no
 # all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
 confidence=
 
-# Enable the message, report, category or checker with the given id(s). You can
+# Enable the message, ceport, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time. See also the "--disable" option for examples.
 #enable=
@@ -75,7 +75,8 @@ output-format=text
 files-output=no
 
 # Tells whether to display a full report or only the messages
-reports=yes
+#reports=yes
+reports=no
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note). You have access to the variables errors warning, statement which
@@ -224,7 +225,8 @@ logging-modules=logging
 [MISCELLANEOUS]
 
 # List of note tags to take in consideration, separated by a comma.
-notes=FIXME,XXX,TODO
+#notes=FIXME,XXX,TODO
+notes=FIXME
 
 
 [SIMILARITIES]

--- a/{{ cookiecutter.project_pkg_name }}/tox.ini
+++ b/{{ cookiecutter.project_pkg_name }}/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = py{35,36}
+envlist = py35,py36
 skipsdist = true
 
 [testenv]
 passenv=
   PIP_*
 whitelist_externals = bash
-deps = -r{toxinidir}/dev-requirements.txt
-commands = python setup.py {posargs}
+deps =
+    -r{toxinidir}/dev-requirements.txt
+commands =
+    python setup.py {posargs}

--- a/{{ cookiecutter.project_pkg_name }}/{{ cookiecutter.project_module_name }}/__init__.py
+++ b/{{ cookiecutter.project_pkg_name }}/{{ cookiecutter.project_module_name }}/__init__.py
@@ -3,9 +3,3 @@
 """
 Root module of the {{ cookiecutter.project_pkg_name }} package.
 """
-
-
-__version__ = '{{ cookiecutter.version }}'
-"""The package version."""
-
-


### PR DESCRIPTION
* Pylint was not wired in completely, so fixed that
  * The 'lint' makefile target in the template was wrong
  * The dev-requirements.txt in the template was missing pylint
* Removed tox dependency from outermost Makefile (the test harness for the template itself)
* Updated template's pylintrc to have terse reporting and allow for TODO comments
* Removed trailing whitespace from template's src code