### PR TITLE
Releasing to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 example-project/
 .tox/
-.virtualenv/
+.venv/
+.testvenv/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2017 , Phil Chandler
+Copyright (c) 2016-2018 , Phil Chandler
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,29 @@
 SHELL := /bin/bash
 
-.PHONY: all clean clean_all test example-project
+.PHONY: all build clean clean_all test virtualenv
 
-all: clean test
+all: clean build test
 
 clean:
-	-rm -r example-project
+	-rm -r example-project/
 
 clean_all: clean
-	-rm -r .virtualenv
+	-rm -r .venv/
+	-rm -r .testvenv/
 
-.virtualenv/bin/activate:
-	virtualenv -p python3 .virtualenv
-	.virtualenv/bin/pip3 install cookiecutter tox
+.venv/bin/activate:
+	virtualenv -p python3 .venv
+	.venv/bin/pip install cookiecutter tox
 
-example-project: .virtualenv/bin/activate
-	source .virtualenv/bin/activate && cookiecutter . --no-input
+virtualenv: .venv/bin/activate
 
-test: example-project .virtualenv/bin/activate
-	source .virtualenv/bin/activate && cd ./example-project && make
+build: virtualenv
+	.venv/bin/cookiecutter . --no-input --overwrite-if-exists
+
+test:
+	cd ./example-project && make
+	-rm .testvenv/
+	virtualenv -p python3 .testvenv
+	.testvenv/bin/pip install -r ./example-project/requirements.txt
+	.testvenv/bin/pip install ./example-project/dist/example_project-0.1.0-py3-none-any.whl
+

--- a/{{ cookiecutter.project_pkg_name }}/.gitignore
+++ b/{{ cookiecutter.project_pkg_name }}/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 
 # test coverage
 .coverage
+htmlcov/

--- a/{{ cookiecutter.project_pkg_name }}/AUTHORS.rst
+++ b/{{ cookiecutter.project_pkg_name }}/AUTHORS.rst
@@ -1,5 +1,5 @@
 =======
-Credits
+Authors
 =======
 
 Development Lead(s)
@@ -10,6 +10,6 @@ Development Lead(s)
 Contributors
 ************
 
-None yet. Why not be the first?
+None yet.
 
 

--- a/{{ cookiecutter.project_pkg_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.project_pkg_name }}/CONTRIBUTING.rst
@@ -2,6 +2,3 @@
 Contributing
 ============
 
-Contributions are welcome, and they are greatly appreciated!
-Every little bit helps, and credit will always be given.
-

--- a/{{ cookiecutter.project_pkg_name }}/Makefile
+++ b/{{ cookiecutter.project_pkg_name }}/Makefile
@@ -1,52 +1,33 @@
-#
-# Taken in large part from https://raw.githubusercontent.com/audreyr/cookiecutter-pypackage/master/%7B%7Bcookiecutter.project_slug%7D%7D/Makefile
-#
-
 SHELL := /bin/bash
 export TOXENV = $(shell python3 -c "import sys; print(\"py{}{}\".format(sys.version_info.major, sys.version_info.minor))")
 
-## setup default target
-all: clean lint test dist
+.PHONY: all build clean dist lint test
 
-## remove all build, test, coverage and Python artifacts
-clean: clean_build clean_pyc clean_test
+all: clean lint test build dist
 
-## remote all transient artifacts
-clean_all: clean clean_tox
+clean:
+	-rm -rv build/ dist/ .eggs/ *.egg-info/
+	-find . -name "*.pyc" -delete
+	-find . -name "*.pyo" -delete
+	-find . -name "__pycache__" -delete
+	-find . -name '*.egg' -delete
 
-## remove .tox etc.
-clean_tox:
-	-rm -rfv .tox
+clean_all: clean
+	-rm -rv .tox
+	-rm -f .coverage htmlcov/
 
-## remove build artifacts
-clean_build:
-	-rm -frv build/ dist/ .eggs/
-	-find . -name '*.egg-info' -exec rm -fr {} +
-	-find . -name '*.egg' -exec rm -f {} +
-
-## remove Python file artifacts
-clean_pyc:
-	find . -name '*.pyc' -exec rm -f {} +
-	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +
-	find . -name '__pycache__' -exec rm -fr {} +
-
-## remove test and coverage artifacts
-clean_test:
-	rm -fr .tox/
-	rm -f .coverage
-	rm -fr htmlcov/
-
-## lint with pylint
-lint:
+.tox/$(TOXENV)/bin/pylint:
 	tox --notest
-	.tox/$(TOXENV)/bin/pylint --rcfile pylintrc {{ cookiecutter.project_module_name }}
 
-## run tests
+lint: .tox/$(TOXENV)/bin/pylint
+	.tox/$(TOXENV)/bin/pylint example_project
+
 test:
 	tox -- test
 
-## build source and wheel distribution packages
+build:
+	tox -- build
+
 dist: clean
 	tox -- sdist
 	tox -- bdist_wheel

--- a/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
@@ -2,14 +2,16 @@
 # Requirements used for development of this project
 #
 
-# Test dependencies
-mock==2.0.0
-pytest==3.0.7
-pytest-runner==2.11.1
-pytest-cov==2.4.0
+# install dependencies used for build, test etc. only
+mock == 2.0.0
+pip >= 9.0.3
+pylint==1.9.2
+pytest == 3.6.3
+pytest-cov == 2.5.1.
+pytest-runner == 4.2
+setuptools >= 40.0.0
+wheel >= 0.31.1
 
-# Install dependencies
+# install dependencies needed at install/runtime
 -r requirements.txt
 
-# General dev dependencies
-pylint==1.7.1

--- a/{{ cookiecutter.project_pkg_name }}/setup.cfg
+++ b/{{ cookiecutter.project_pkg_name }}/setup.cfg
@@ -1,51 +1,28 @@
-[metadata]
-name = {{ cookiecutter.project_pkg_name }}
-version = {{ cookiecutter.version }}
-
-description = {{ cookiecutter.project_description }}
-long_description = file: README.rst
-url = 
-
-author = {{ cookiecutter.author_name }}
-author_email = {{ cookiecutter.author_email }}
-
-license = BSD 3-Clause License
-
-classifiers =
-    Development Status :: 3 - Alpha
-    Intended Audience :: Developers
-    Topic :: Software Development
-    License :: OSI Approved :: BSD License
-    Programming Language :: Python :: 3
-
-keywords = ''
-
-[options]
-install_requires =
-    boltons >= 17.1.0, < 18.0.0
-
-tests_require =
-    # Use the separately packaged mock to avoid bugs in the embedded
-    # version in some Python interpreters
-    mock >= 2.0.0, < 3.0.0
-    pytest >= 3.0.7, < 4.0.0
-    pytest-runner >= 2.11.1, < 3.0
-    pytest-cov >= 2.4.0, < 3.0.0
-
-include_package_data =  True
-packages = find:
-
-[options.packages.find]
-include = {{ cookiecutter.project_module_name }}
-
 [aliases]
 test=pytest
 
 [tool:pytest]
-addopts = --cov={{ cookiecutter.project_module_name }} --cov-report term-missing tests/ 
+addopts = --cov={{ cookiecutter.project_module_name }} --cov-report term tests/ 
 
 [wheel]
-# this is a Python3 only wheel
 universal = 0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/{{ cookiecutter.project_pkg_name }}/setup.py
+++ b/{{ cookiecutter.project_pkg_name }}/setup.py
@@ -1,13 +1,56 @@
-# -*- coding: utf-8 -*-
-
 """
 A setuptools based setup module.
-
-Loosely based on https://github.com/pypa/sampleproject/blob/master/setup.py
-
 """
 
-# Always prefer setuptools over distutils
-from setuptools import setup
+import setuptools
+import os
 
-setup()
+
+def read_long_description():
+    """Read the long description text from the README.rst file"""
+    path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.rst')
+    with open(path, encoding='utf-8') as input_file:
+        text = input_file.read()
+    return text
+
+setuptools.setup(
+    author='{{ cookiecutter.author_name }}',
+    author_email='{{ cookiecutter.author_email }}',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development ',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 3',
+    ],
+    data_files=[],
+    description='{{ cookiecutter.project_description }}',
+    entry_points={},
+    extras_require={},
+    include_package_data=True,
+    install_requires=[
+        "boltons >= 17.1.0, < 18.0.0",
+    ],
+    keywords='',
+    license='BSD',
+    long_description=read_long_description(),
+    name='{{ cookiecutter.project_pkg_name }}',
+    packages=[
+        '{{ cookiecutter.project_module_name }}',
+    ],
+    package_data={},
+    setup_requires=[
+        "pytest-runner >= 4.2",
+    ],
+    tests_require=[
+        "mock >= 2.0.0",
+        "pytest >= 3.6.3",
+        "pytest-cov >= 2.5.1",
+    ],
+    test_suite = 'tests',
+    url='',
+    version='{{ cookiecutter.version }}',
+)
+
+
+


### PR DESCRIPTION
Rewrote a lot of the template because the last round of changes to it introduced some breakage, and because I wanted to clean up the implementation based on lessons learned in the meantime.

Highlights are:

* Migrated most of setup.cfg back into setup.py
  * Had to do this because wheel+setuptools integration is sketchy when in comes to support for setup.cfg
* Expanded smoke test of the template
  * Does a run of the template, uses the emitted template's makefile to build a wheel file, and then does a smoke test of installing that wheel to a test virtualenv.
  * Very very crude but better than nothing.
* Fixed mistakes/misdesigns in both the top-level Makefile and the one in the emitted project.
* Updated dependency versions used by emitted project.