### PR TITLE
Release of new edition

### DIFF
--- a/{{ cookiecutter.project_pkg_name }}/Makefile
+++ b/{{ cookiecutter.project_pkg_name }}/Makefile
@@ -20,7 +20,7 @@ clean_all: clean
 	tox --notest
 
 lint: .tox/$(TOXENV)/bin/pylint
-	.tox/$(TOXENV)/bin/pylint example_project
+	.tox/$(TOXENV)/bin/pylint {{ cookiecutter.project_module_name }}
 
 test:
 	tox -- test

--- a/{{ cookiecutter.project_pkg_name }}/Makefile
+++ b/{{ cookiecutter.project_pkg_name }}/Makefile
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 export TOXENV = $(shell python3 -c "import sys; print(\"py{}{}\".format(sys.version_info.major, sys.version_info.minor))")
 
-.PHONY: all build clean dist lint test
+.PHONY: all build clean dist lint lint_tests test
 
-all: clean lint test build dist
+all: clean lint lint_tests test build dist
 
 clean:
 	-rm -rv build/ dist/ .eggs/ *.egg-info/
@@ -21,6 +21,9 @@ clean_all: clean
 
 lint: .tox/$(TOXENV)/bin/pylint
 	.tox/$(TOXENV)/bin/pylint {{ cookiecutter.project_module_name }}
+
+lint_tests: .tox/$(TOXENV)/bin/pylint
+	.tox/$(TOXENV)/bin/pylint --errors-only tests
 
 test:
 	tox -- test

--- a/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.project_pkg_name }}/dev-requirements.txt
@@ -10,6 +10,7 @@ pytest == 3.6.3
 pytest-cov == 2.5.1.
 pytest-runner == 4.2
 setuptools >= 40.0.0
+testfixtures == 6.2.0
 wheel >= 0.31.1
 
 # install dependencies needed at install/runtime

--- a/{{ cookiecutter.project_pkg_name }}/pylintrc
+++ b/{{ cookiecutter.project_pkg_name }}/pylintrc
@@ -186,7 +186,7 @@ max-nested-blocks=5
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=124
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/{{ cookiecutter.project_pkg_name }}/setup.py
+++ b/{{ cookiecutter.project_pkg_name }}/setup.py
@@ -43,9 +43,10 @@ setuptools.setup(
         "pytest-runner >= 4.2",
     ],
     tests_require=[
-        "mock >= 2.0.0",
-        "pytest >= 3.6.3",
-        "pytest-cov >= 2.5.1",
+        'mock >= 2.0.0',
+        'pytest >= 3.6.3',
+        'pytest-cov >= 2.5.1',
+	'testfixtures >= 6.2.0',
     ],
     test_suite = 'tests',
     url='',


### PR DESCRIPTION
**Bug fixes**

In the template itself:
* Fixed bug in Makefile where the parameterized name for the project was not being used

**Refactors**

In the template itself:

* Changed line length limit to 124 in pylintrc (fits common Python styles in the wild and is a decent compromise between readability and code writing ergonomics for me)

**New Features**

In the template itself:

* Added target to Makefile for running pylint in errors-only mode against the test source code
* Added the ``testfixtures`` package as a test dependency.  Very handy for comparing dicts of lists with each other (as well as other nested data structures).